### PR TITLE
refactor: 나라 선택 리스트 default를 랭킹 10개만 나타나도록 하라

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -11,11 +11,14 @@ export const metadata = {
 };
 
 function Page() {
+  const topRankingCountries = ['JP', 'US', 'TH', 'VN', 'HK', 'TW', 'PH', 'SG', 'FR'];
+
   const countries = useMemo(() => ISO_3166_COUNTRY_CODES
     .reduce((prev: Country[], curr) => [
       ...prev, {
         ...curr,
         emoji: codeToFlag(curr.code),
+        ranking: topRankingCountries.findIndex((value) => value === curr.code),
       },
     ], []), []);
 

--- a/components/about/CountryList.test.tsx
+++ b/components/about/CountryList.test.tsx
@@ -8,11 +8,13 @@ describe('CountryList', () => {
     koreanName: '북한',
     englishName: 'Korea, Democratic People"S Republic of',
     emoji: '🇰🇵',
+    ranking: -1,
   }, {
     code: 'KR',
     koreanName: '대한민국',
     englishName: 'Korea, Republic of',
     emoji: '🇰🇷',
+    ranking: 0,
   }];
 
   const renderCountryList = () => render((
@@ -25,10 +27,9 @@ describe('CountryList', () => {
   context('keyword가 존재하지 않는 경우', () => {
     given('keyword', () => '');
 
-    it('전체 나라 리스트가 나타나야만 한다', () => {
+    it('랭킹 나라 리스트가 나타나야만 한다', () => {
       const { container } = renderCountryList();
 
-      expect(container).toHaveTextContent(countries[0].koreanName);
       expect(container).toHaveTextContent(countries[1].koreanName);
     });
   });

--- a/components/about/CountryList.tsx
+++ b/components/about/CountryList.tsx
@@ -1,4 +1,6 @@
-import { memo, useEffect, useState } from 'react';
+import {
+  memo, useEffect, useMemo, useState,
+} from 'react';
 
 import { Country } from 'lib/types/country';
 import styled from 'styled-components';
@@ -11,11 +13,16 @@ type Props = {
 };
 
 function CountryList({ keyword, countries }: Props) {
-  const [state, setState] = useState<Country[]>(countries);
+  const rankingCountries = useMemo(() => [...countries
+    .filter(({ ranking }) => ranking !== -1)]
+    .sort((a, b) => a.ranking - b.ranking), [countries]);
+
+  const [state, setState] = useState<Country[]>(rankingCountries);
 
   useEffect(() => {
     if (!keyword.trim()) {
-      setState(countries);
+      setState(rankingCountries);
+      return;
     }
 
     setState(countries.filter(({ englishName, koreanName }) => {

--- a/components/about/SearchCountry.test.tsx
+++ b/components/about/SearchCountry.test.tsx
@@ -11,6 +11,7 @@ describe('SearchCountry', () => {
       code: 'kr',
       englishName: countryName,
       koreanName: countryName,
+      ranking: 1,
     }]}
     />
   ));

--- a/components/map/SampleMap.tsx
+++ b/components/map/SampleMap.tsx
@@ -16,6 +16,7 @@ function SampleMap() {
   const { isLoaded, loadError } = useLoadScript({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY,
     libraries,
+    region: 'KR',
   });
 
   const [markers, setMarkers] = useState<google.maps.Marker[]>([]);

--- a/lib/assets/data/iso3166CountryCodes.ts
+++ b/lib/assets/data/iso3166CountryCodes.ts
@@ -1087,7 +1087,7 @@ const ISO_3166_COUNTRY_CODES = [
   },
   {
     code: 'TH',
-    koreanName: '타이',
+    koreanName: '태국',
     englishName: 'Thailand',
   },
   {
@@ -1137,7 +1137,7 @@ const ISO_3166_COUNTRY_CODES = [
   },
   {
     code: 'TW',
-    koreanName: '타이완',
+    koreanName: '대만',
     englishName: 'Taiwan, Province of China',
   },
   {

--- a/lib/types/country.ts
+++ b/lib/types/country.ts
@@ -3,4 +3,5 @@ export type Country = {
   englishName: string;
   code: string;
   emoji: string;
+  ranking: number;
 };


### PR DESCRIPTION
- 전체 리스트를 상단 랭킹 10개의 나라만 노출
- 검색 시 전체 나라 검색 가능
- 정적인 나라 데이터 한국어 수정
- google map region 추가