### PR TITLE
feat: naver search api 호출 1초당 10회 limit으로 인해 api delay 적용

### DIFF
--- a/components/map/placeBottomSheet/index.tsx
+++ b/components/map/placeBottomSheet/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { BottomSheet } from 'react-spring-bottom-sheet';
 
 import { useQuery } from '@tanstack/react-query';
-import { fetchNaverSearchBlog } from 'lib/apis/search';
+import { fetchAllSettledSearchBlogs } from 'lib/apis/search';
 import { PlaceResult } from 'lib/types/google.maps';
 
 import Button from 'components/common/button';
@@ -19,15 +19,13 @@ type Props = {
 };
 
 function PlaceBottomSheet({ placesResult, isZeroResult }: Props) {
-  const [open, setOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const placeName = placesResult.map((place) => place.name);
 
   const { data: placesWithSearchResult, isSuccess } = useQuery(
     [placeName],
-    () => Promise.allSettled([...placeName.map((keyword) => fetchNaverSearchBlog<false>({
-      keyword,
-    }))]),
+    () => fetchAllSettledSearchBlogs<false>({ placeName }),
     {
       enabled: !!placesResult?.length && !isZeroResult,
       select: (searchBlogPosts) => placesResult.map((place, index) => ({
@@ -42,14 +40,17 @@ function PlaceBottomSheet({ placesResult, isZeroResult }: Props) {
 
   useEffect(() => {
     if (isSuccess || isZeroResult) {
-      setOpen(true);
+      setIsOpen(true);
+      return;
     }
+
+    setIsOpen(false);
   }, [isSuccess, isZeroResult]);
 
   return (
     <>
       <BottomSheet
-        open={open}
+        open={isOpen}
         blocking={false}
         defaultSnap={({ maxHeight }) => (isZeroResult ? 168 : maxHeight / 2)}
         snapPoints={({ maxHeight }) => (isZeroResult ? [168] : [

--- a/lib/apis/search/index.ts
+++ b/lib/apis/search/index.ts
@@ -29,21 +29,15 @@ export const fetchAllSettledSearchBlogs = async <T = boolean>({
   const copyPlaceName = [...placeName];
   const firstPlaceName = copyPlaceName.splice(0, BATCH_SIZE);
 
-  if (placeName.length <= 10) {
-    const response = await Promise
-      .allSettled([...firstPlaceName.map((keyword) => fetchNaverSearchBlog<T>({
-        keyword,
-        includePost,
-      }))]);
-
-    return response;
-  }
-
   const firstResponse = await Promise
     .allSettled([...firstPlaceName.map((keyword) => fetchNaverSearchBlog<T>({
       keyword,
       includePost,
     }))]);
+
+  if (placeName.length <= 10) {
+    return firstPlaceName;
+  }
 
   await new Promise((resolve) => {
     setTimeout(resolve, DELAY);

--- a/lib/apis/search/index.ts
+++ b/lib/apis/search/index.ts
@@ -2,7 +2,9 @@ import { api, paramsSerializer } from '..';
 
 import { NaverSearchBlogResponse } from './model';
 
-// eslint-disable-next-line import/prefer-default-export
+const BATCH_SIZE = 10;
+const DELAY = 1000;
+
 export const fetchNaverSearchBlog = async <T = boolean>({
   keyword, includePost,
 }: { keyword: string; includePost?: T; }) => {
@@ -17,4 +19,41 @@ export const fetchNaverSearchBlog = async <T = boolean>({
   });
 
   return response;
+};
+
+export const fetchAllSettledSearchBlogs = async <T = boolean>({
+  placeName, includePost,
+}: {
+  placeName: string[]; includePost?: T;
+}) => {
+  const copyPlaceName = [...placeName];
+  const firstPlaceName = copyPlaceName.splice(0, BATCH_SIZE);
+
+  if (placeName.length <= 10) {
+    const response = await Promise
+      .allSettled([...firstPlaceName.map((keyword) => fetchNaverSearchBlog<T>({
+        keyword,
+        includePost,
+      }))]);
+
+    return response;
+  }
+
+  const firstResponse = await Promise
+    .allSettled([...firstPlaceName.map((keyword) => fetchNaverSearchBlog<T>({
+      keyword,
+      includePost,
+    }))]);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, DELAY);
+  });
+
+  const secondResponse = await Promise
+    .allSettled([...copyPlaceName.map((keyword) => fetchNaverSearchBlog<T>({
+      keyword,
+      includePost,
+    }))]);
+
+  return [...firstResponse, ...secondResponse];
 };

--- a/lib/apis/search/index.ts
+++ b/lib/apis/search/index.ts
@@ -36,7 +36,7 @@ export const fetchAllSettledSearchBlogs = async <T = boolean>({
     }))]);
 
   if (placeName.length <= 10) {
-    return firstPlaceName;
+    return firstResponse;
   }
 
   await new Promise((resolve) => {


### PR DESCRIPTION
- naver search api 1초당 10회 limit이 되어있어 1초당 10회로 제한하여 호출하도록 적용
- 10개 미만인 경우 delay x
- 10개 이상인 경우 delay 1초