### PR TITLE
feat: 상세 > 타이틀 위치 변경 및 스크롤 이동하도록 적용

### DIFF
--- a/src/components/detail/PlaceDetailWindow/index.module.scss
+++ b/src/components/detail/PlaceDetailWindow/index.module.scss
@@ -25,12 +25,17 @@
       justify-content: center;
       align-items: center;
       padding: 0 16px;
+      margin-top: 136px;
+      position: relative;
 
       .bodyHeader {
         text-align: center;
         word-break: keep-all;
         overflow-wrap: anywhere;
         margin-bottom: 80px;
+        position: absolute;
+        top: -136px;
+        z-index: var(--detail-window-title-z-index);
 
         @include text("display/700", "black/default");
       }

--- a/src/components/detail/PlaceDetailWindow/index.tsx
+++ b/src/components/detail/PlaceDetailWindow/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
@@ -53,6 +53,7 @@ function PlaceDetailWindow({
 }: Props) {
   console.log(placeDetail);
   const renderToast = useRenderToast();
+  const placePhotoRef = useRef<HTMLDivElement>(null);
   const params = useSearchParams();
 
   const isVisibleLoading = isVisible && (isLoading || !placeDetail);
@@ -107,6 +108,12 @@ function PlaceDetailWindow({
     document.body.style.overflow = '';
   });
 
+  useEffect(() => {
+    if (!isLoading && placeDetail && placePhotoRef?.current) {
+      placePhotoRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [isLoading, placeDetail]);
+
   return (
     <DelayRenderComponent isVisible={isVisible}>
       <GlobalPortal>
@@ -150,7 +157,7 @@ function PlaceDetailWindow({
                 <>
                   <h1 className={styles.bodyHeader}>{placeDetail?.name}</h1>
                   {placeDetail?.photos?.[0] && (
-                    <div className={styles.placeImageWrapper}>
+                    <div className={styles.placeImageWrapper} ref={placePhotoRef}>
                       <Image
                         width={382}
                         height={382}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -179,6 +179,7 @@ $opacity-000: 0;
   --bottom-sheet-z-index: 8;
   --accordion-header-z-index: 1;
   --detail-window-header-z-index: 2;
+  --detail-window-title-z-index: 1;
 }
 
 :root {


### PR DESCRIPTION
- 타이틀이 길어지면 이미지와 타이틀이 겹쳐지도록 적용
- 첫 렌더시 스크롤 위치를 이미지 가운대로 이동