### PR TITLE
refactor: 검색 결과 리스트 api에 캐시 10분 삭제

### DIFF
--- a/src/app/api/google/search/route.ts
+++ b/src/app/api/google/search/route.ts
@@ -4,8 +4,6 @@ import { Client, Language } from '@googlemaps/google-maps-services-js';
 
 export const runtime = 'nodejs';
 
-const TEN_MINUTES = 600;
-
 export async function GET(request: NextRequest) {
   const client = new Client({});
 
@@ -38,12 +36,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(response.data, {
       status: response.status,
       statusText: response.statusText,
-      headers: {
-        ...requestHeaders,
-        'Cache-Control': 'public, s-maxage=1',
-        'CDN-Cache-Control': 'public, s-maxage=60',
-        'Vercel-CDN-Cache-Control': `public, s-maxage=${TEN_MINUTES}`,
-      },
+      headers: requestHeaders,
     });
   }
 

--- a/src/app/api/naver/search/route.ts
+++ b/src/app/api/naver/search/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 
 const TEN_MINUTES = 600;
 

--- a/src/app/api/search/places/[placeId]/route.ts
+++ b/src/app/api/search/places/[placeId]/route.ts
@@ -6,7 +6,7 @@ import { fetchNaverSearchBlog } from '@/app/api/handler';
 import { paramsSerializer } from '@/lib/apis';
 import { PlaceDetail } from '@/lib/types/google.maps';
 
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 
 const TEN_MINUTES = 600;
 

--- a/src/app/api/search/places/route.ts
+++ b/src/app/api/search/places/route.ts
@@ -8,9 +8,7 @@ import { filteredPlaces } from '@/utils';
 
 import { fetchAllSettledSearchNaverBlogs } from '../../handler';
 
-export const runtime = 'edge';
-
-const TEN_MINUTES = 600;
+export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -24,9 +22,6 @@ export async function GET(request: NextRequest) {
     nextCursor,
   })}`, {
     method: 'GET',
-    next: {
-      revalidate: TEN_MINUTES,
-    },
     headers: requestHeaders,
   });
 
@@ -51,11 +46,5 @@ export async function GET(request: NextRequest) {
     results: response,
   }, {
     ...textSearchResponse,
-    headers: {
-      ...textSearchResponse.headers,
-      'Cache-Control': 'public, s-maxage=1',
-      'CDN-Cache-Control': 'public, s-maxage=60',
-      'Vercel-CDN-Cache-Control': `public, s-maxage=${TEN_MINUTES}`,
-    },
   });
 }

--- a/src/hooks/queries/useGetSearchPlace.ts
+++ b/src/hooks/queries/useGetSearchPlace.ts
@@ -8,7 +8,7 @@ const TEN_MINUTES = 600000;
 function useGetSearchPlace({
   placeId, sessionToken,
 }: { placeId?: string; sessionToken?: string; }) {
-  const query = useQuery<SearchPlace>(['placeDetailV2', placeId], () => fetchPlaceDetail({ placeId: placeId as string, sessionToken }), {
+  const query = useQuery<SearchPlace>(['placeDetail', placeId], () => fetchPlaceDetail({ placeId: placeId as string, sessionToken }), {
     enabled: !!placeId,
     staleTime: TEN_MINUTES,
     cacheTime: TEN_MINUTES,

--- a/src/hooks/queries/useGetSearchPlaces.ts
+++ b/src/hooks/queries/useGetSearchPlaces.ts
@@ -5,13 +5,9 @@ import { SearchPlacesResponse } from '@/lib/apis/search/model';
 
 import useIntersectionObserver from '../useIntersectionObserver';
 
-const TEN_MINUTES = 600000;
-
 function useGetSearchPlaces({ keyword }: { keyword: string; }) {
   const query = useInfiniteQuery<SearchPlacesResponse>(['searchPlaces', keyword], ({ pageParam }) => fetchSearchPlaces({ keyword, nextCursor: pageParam }), {
     enabled: !!keyword,
-    staleTime: TEN_MINUTES,
-    cacheTime: TEN_MINUTES,
     getNextPageParam: ({ next_page_token }) => next_page_token,
   });
 


### PR DESCRIPTION
- 위치, 장소에 따라서 달라질 수 있기때문에 삭제
- edge -> nodejs로 변경